### PR TITLE
README update and show error message when pprz_download fails

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -4,10 +4,10 @@ Highspeedlogger Tools:
 pprz_download:
 -------------
 
-Download files from an SD-card written in RAW data format using the Paparazzi SD Direct logger. For linux, SD-card drive name can be found by calling ```ls /dev``` before and after inserting the SD-card. Common names for the SD-card drive include ```/dev/sdb``` and ```/dev/mmcblk0```.
+Download files from an SD-card written in RAW data format using the Paparazzi SD Direct logger. For linux, SD-card drive name can be found by calling ```ls /dev``` before and after inserting the SD-card. Common names for the SD-card drive include ```/dev/sdb``` and ```/dev/mmcblk0```. Su is required.
 
 ```
-./pprz_download <DRIVE>
+sudo ./pprz_download <DRIVE>
 ```
 
 download:

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,7 +4,11 @@ Highspeedlogger Tools:
 pprz_download:
 -------------
 
-Download files from an SD-card written in RAW data format using the Paparazzi SD Direct logger.
+Download files from an SD-card written in RAW data format using the Paparazzi SD Direct logger. For linux, SD-card drive name can be found by calling ```ls /dev``` before and after inserting the SD-card. Common names for the SD-card drive include ```/dev/sdb``` and ```/dev/mmcblk0```.
+
+```
+./pprz_download <DRIVE>
+```
 
 download:
 --------

--- a/tools/pprz_download/pprz_download.cpp
+++ b/tools/pprz_download/pprz_download.cpp
@@ -122,7 +122,7 @@ extern bool parse_pprz(struct pprz_transport *t, uint8_t c);
 
 // Start byte
 #define PPRZ_STX  0x99
-	
+
 // Parsing function
 bool parse_pprz(struct pprz_transport *t, uint8_t c)
 {
@@ -186,14 +186,16 @@ void read_disk_raw(char* volume_name, unsigned long disk_size)
     int k = 0;
     uint8_t buf[BUFF_SIZE] = {0};
     uint8_t bufheader[BUFF_SIZE] = {0};
-  
+
     volume = fopen(volume_name, "r+b");
     if(!volume)
     {
-        printf("Cant open Drive '%s'\n", volume_name);
-		fclose(volume);
-        return;
-    }
+			char error_message[50];
+			sprintf(error_message, "Can't open drive '%s'", volume_name);
+			perror(error_message); // This will output the reason for fopen failure to terminal
+			fclose(volume);
+			return;
+		}
     setbuf(volume, NULL);       // Disable buffering
 
 	int log = -1;
@@ -329,7 +331,7 @@ void read_disk_raw(char* volume_name, unsigned long disk_size)
 	fclose(of);
 
     fclose(volume);
- 
+
     return;
 }
 

--- a/tools/pprz_download/pprz_download.cpp
+++ b/tools/pprz_download/pprz_download.cpp
@@ -191,7 +191,7 @@ void read_disk_raw(char* volume_name, unsigned long disk_size)
     if(!volume)
     {
 			char error_message[50];
-			sprintf(error_message, "Can't open drive '%s'", volume_name);
+			sprintf(error_message, "Can't open drive '%s' (make sure you are su)", volume_name);
 			perror(error_message); // This will output the reason for fopen failure to terminal
 			fclose(volume);
 			return;


### PR DESCRIPTION
- Add comment on SD-card name in README
- Error message is now displayed in terminal when fopen fails in pprz_download